### PR TITLE
Allow the use of a custom model

### DIFF
--- a/config/filepond.php
+++ b/config/filepond.php
@@ -40,6 +40,16 @@ return [
         'web', 'auth'
     ],
 
+	/*
+	|--------------------------------------------------------------------------
+	| Filepond Model
+	|--------------------------------------------------------------------------
+	|
+	| If you need to  customize the model, create a new one an extends the default model \RahulHaque\Filepond\Models\Filepond::class
+	|
+	*/
+	'model' => \RahulHaque\Filepond\Models\Filepond::class,
+
     /*
     |--------------------------------------------------------------------------
     | Soft Delete FilePond Model

--- a/src/AbstractFilepond.php
+++ b/src/AbstractFilepond.php
@@ -107,7 +107,7 @@ abstract class AbstractFilepond
         }
 
         if ($this->getIsMultipleUpload()) {
-            $this->fieldModel = config('filepond.model')::when($this->isOwnershipAware, function ($query) {
+            $this->fieldModel = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::when($this->isOwnershipAware, function ($query) {
                 $query->owned();
             })
                 ->whereIn('id', (new Collection($this->getFieldValue()))->pluck('id'))
@@ -116,7 +116,7 @@ abstract class AbstractFilepond
         }
 
         $input = $this->getFieldValue();
-        $this->fieldModel = config('filepond.model')::when($this->isOwnershipAware, function ($query) {
+        $this->fieldModel = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::when($this->isOwnershipAware, function ($query) {
             $query->owned();
         })
             ->where('id', $input['id'])

--- a/src/AbstractFilepond.php
+++ b/src/AbstractFilepond.php
@@ -6,7 +6,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Storage;
-use RahulHaque\Filepond\Models\Filepond;
+use RahulHaque\Filepond\Interfaces\FilePondInterface;
 
 abstract class AbstractFilepond
 {
@@ -107,7 +107,7 @@ abstract class AbstractFilepond
         }
 
         if ($this->getIsMultipleUpload()) {
-            $this->fieldModel = Filepond::when($this->isOwnershipAware, function ($query) {
+            $this->fieldModel = config('filepond.model')::when($this->isOwnershipAware, function ($query) {
                 $query->owned();
             })
                 ->whereIn('id', (new Collection($this->getFieldValue()))->pluck('id'))
@@ -116,7 +116,7 @@ abstract class AbstractFilepond
         }
 
         $input = $this->getFieldValue();
-        $this->fieldModel = Filepond::when($this->isOwnershipAware, function ($query) {
+        $this->fieldModel = config('filepond.model')::when($this->isOwnershipAware, function ($query) {
             $query->owned();
         })
             ->where('id', $input['id'])
@@ -182,10 +182,10 @@ abstract class AbstractFilepond
     /**
      * Create file object from filepond model
      *
-     * @param  Filepond  $filepond
+     * @param  FilePondInterface  $filepond
      * @return UploadedFile
      */
-    protected function createFileObject(Filepond $filepond)
+    protected function createFileObject(FilePondInterface $filepond)
     {
         return new UploadedFile(
             Storage::disk($this->tempDisk)->path($filepond->filepath),
@@ -200,11 +200,11 @@ abstract class AbstractFilepond
      * Create Data URL from filepond model
      * More at - https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
      *
-     * @param  Filepond  $filepond
+     * @param  FilePondInterface  $filepond
      * @return string
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    protected function createDataUrl(Filepond $filepond)
+    protected function createDataUrl(FilePondInterface $filepond)
     {
         return 'data:'.$filepond->mimetypes.';base64,'.base64_encode(Storage::disk($this->tempDisk)->get($filepond->filepath));
     }

--- a/src/Console/FilepondClear.php
+++ b/src/Console/FilepondClear.php
@@ -4,7 +4,6 @@ namespace RahulHaque\Filepond\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
-use RahulHaque\Filepond\Models\Filepond;
 
 class FilepondClear extends Command
 {
@@ -44,7 +43,7 @@ class FilepondClear extends Command
 
         if ($this->option('all')) {
             if ($this->confirm('Are you sure?', true)) {
-                Filepond::truncate();
+                config('filepond.model')::truncate();
                 $this->info('Fileponds table truncated.');
                 Storage::disk($tempDisk)->deleteDirectory($tempFolder);
                 $this->info('Temporary files and folders deleted.');
@@ -54,7 +53,7 @@ class FilepondClear extends Command
             return 0;
         }
 
-        $expiredFiles = Filepond::withTrashed()->where('expires_at', '<=', now())->select(['id', 'filepath']);
+        $expiredFiles = config('filepond.model')::withTrashed()->where('expires_at', '<=', now())->select(['id', 'filepath']);
         $this->info('Total expired files and folders: '.$expiredFiles->count());
         if ($expiredFiles->count() > 0) {
             foreach ($expiredFiles->get() as $expiredFile) {

--- a/src/Console/FilepondClear.php
+++ b/src/Console/FilepondClear.php
@@ -43,7 +43,7 @@ class FilepondClear extends Command
 
         if ($this->option('all')) {
             if ($this->confirm('Are you sure?', true)) {
-                config('filepond.model')::truncate();
+                config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::truncate();
                 $this->info('Fileponds table truncated.');
                 Storage::disk($tempDisk)->deleteDirectory($tempFolder);
                 $this->info('Temporary files and folders deleted.');
@@ -53,7 +53,7 @@ class FilepondClear extends Command
             return 0;
         }
 
-        $expiredFiles = config('filepond.model')::withTrashed()->where('expires_at', '<=', now())->select(['id', 'filepath']);
+        $expiredFiles = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::withTrashed()->where('expires_at', '<=', now())->select(['id', 'filepath']);
         $this->info('Total expired files and folders: '.$expiredFiles->count());
         if ($expiredFiles->count() > 0) {
             foreach ($expiredFiles->get() as $expiredFile) {

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -3,7 +3,8 @@
 namespace RahulHaque\Filepond;
 
 use Illuminate\Support\Facades\Storage;
-use RahulHaque\Filepond\Models\Filepond as FilepondModel;
+use RahulHaque\Filepond\Interfaces\FilePondInterface;
+
 
 class Filepond extends AbstractFilepond
 {
@@ -173,14 +174,14 @@ class Filepond extends AbstractFilepond
     /**
      * Put the file in permanent storage and return response
      *
-     * @param  FilepondModel  $filepond
+     * @param  FilePondInterface $filepond
      * @param  string  $path
      * @param  string  $disk
      * @param  string  $visibility
      * @return array
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    private function putFile(FilepondModel $filepond, string $path, string $disk, string $visibility)
+    private function putFile(FilePondInterface $filepond, string $path, string $disk, string $visibility)
     {
         $permanentDisk = $disk == '' ? $filepond->disk : $disk;
 

--- a/src/Interfaces/FilePondInterface.php
+++ b/src/Interfaces/FilePondInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RahulHaque\Filepond\Interfaces;
+
+interface FilePondInterface
+{
+	public function scopeOwned($query);
+
+	public function creator();
+
+	public function delete();
+
+	public function forceDelete();
+}

--- a/src/Models/Filepond.php
+++ b/src/Models/Filepond.php
@@ -5,8 +5,9 @@ namespace RahulHaque\Filepond\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use RahulHaque\Filepond\Interfaces\FilePondInterface;
 
-class Filepond extends Model
+class Filepond extends Model implements FilePondInterface
 {
     use HasFactory, SoftDeletes;
 

--- a/src/Services/FilepondService.php
+++ b/src/Services/FilepondService.php
@@ -59,7 +59,7 @@ class FilepondService
 	{
 		$file = $this->getUploadedFile($request);
 
-		$filepond = config('filepond.model')::create([
+		$filepond = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::create([
 			'filepath' => $file->store($this->tempFolder, $this->tempDisk),
 			'filename' => $file->getClientOriginalName(),
 			'extension' => $file->getClientOriginalExtension(),
@@ -82,7 +82,7 @@ class FilepondService
 	{
 		$input = Crypt::decrypt($content);
 
-		return config('filepond.model')::owned()
+		return config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::owned()
 		                               ->where('id', $input['id'])
 		                               ->firstOrFail();
 	}
@@ -94,7 +94,7 @@ class FilepondService
 	 */
 	public function initChunk()
 	{
-		$filepond = config('filepond.model')::create([
+		$filepond = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::create([
 			'filepath' => '',
 			'filename' => '',
 			'extension' => '',

--- a/src/Traits/HasFilepond.php
+++ b/src/Traits/HasFilepond.php
@@ -11,6 +11,6 @@ trait HasFilepond {
      */
     public function fileponds()
     {
-        return $this->hasMany(config('filepond.model'), 'created_by');
+        return $this->hasMany(config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class), 'created_by');
     }
 }

--- a/src/Traits/HasFilepond.php
+++ b/src/Traits/HasFilepond.php
@@ -2,8 +2,6 @@
 
 namespace RahulHaque\Filepond\Traits;
 
-use RahulHaque\Filepond\Models\Filepond;
-
 trait HasFilepond {
 
     /**
@@ -13,6 +11,6 @@ trait HasFilepond {
      */
     public function fileponds()
     {
-        return $this->hasMany(Filepond::class, 'created_by');
+        return $this->hasMany(config('filepond.model'), 'created_by');
     }
 }

--- a/tests/Feature/FilepondStorageClearTest.php
+++ b/tests/Feature/FilepondStorageClearTest.php
@@ -5,7 +5,6 @@ namespace RahulHaque\Filepond\Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use RahulHaque\Filepond\Models\Filepond;
 use RahulHaque\Filepond\Tests\TestCase;
 use RahulHaque\Filepond\Tests\User;
 
@@ -31,7 +30,7 @@ class FilepondStorageClearTest extends TestCase
         }
 
         // Update expire_at time to make them ready to clean
-        Filepond::query()->update([
+        config('filepond.model')::query()->update([
             'expires_at' => now()->subMinutes(5)
         ]);
 

--- a/tests/Feature/FilepondStorageClearTest.php
+++ b/tests/Feature/FilepondStorageClearTest.php
@@ -30,7 +30,7 @@ class FilepondStorageClearTest extends TestCase
         }
 
         // Update expire_at time to make them ready to clean
-        config('filepond.model')::query()->update([
+        config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::query()->update([
             'expires_at' => now()->subMinutes(5)
         ]);
 

--- a/tests/Unit/FilepondModelTest.php
+++ b/tests/Unit/FilepondModelTest.php
@@ -4,8 +4,8 @@ namespace RahulHaque\Filepond\Tests\Unit;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
-use RahulHaque\Filepond\Models\Filepond;
 use RahulHaque\Filepond\Tests\TestCase;
+use RahulHaque\Filepond\Tests\User;
 
 class FilepondModelTest extends TestCase
 {
@@ -24,7 +24,7 @@ class FilepondModelTest extends TestCase
             'expires_at' => now()->addMinutes(30)->toISOString()
         ];
 
-        Filepond::create($data);
+        config('filepond.model')::create($data);
 
         $this->assertDatabaseHas('fileponds', $data);
     }
@@ -32,7 +32,7 @@ class FilepondModelTest extends TestCase
     /** @test */
     function can_update_filepond_model()
     {
-        $filepond = Filepond::create([
+        $filepond = config('filepond.model')::create([
             'filepath' => Storage::disk(config('filepond.disk', 'public'))->path('fake_filename.png'),
             'filename' => 'fake_filename.png',
             'extension' => 'png',
@@ -53,7 +53,7 @@ class FilepondModelTest extends TestCase
     /** @test */
     function can_soft_delete_filepond_model()
     {
-        $filepond = Filepond::create([
+        $filepond = config('filepond.model')::create([
             'filepath' => Storage::disk(config('filepond.disk', 'public'))->path('fake_filename.png'),
             'filename' => 'fake_filename.png',
             'extension' => 'png',
@@ -71,7 +71,7 @@ class FilepondModelTest extends TestCase
     /** @test */
     function can_force_delete_filepond_model()
     {
-        $filepond = Filepond::create([
+        $filepond = config('filepond.model')::create([
             'filepath' => Storage::disk(config('filepond.disk', 'public'))->path('fake_filename.png'),
             'filename' => 'fake_filename.png',
             'extension' => 'png',

--- a/tests/Unit/FilepondModelTest.php
+++ b/tests/Unit/FilepondModelTest.php
@@ -24,7 +24,7 @@ class FilepondModelTest extends TestCase
             'expires_at' => now()->addMinutes(30)->toISOString()
         ];
 
-        config('filepond.model')::create($data);
+        config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::create($data);
 
         $this->assertDatabaseHas('fileponds', $data);
     }
@@ -32,7 +32,7 @@ class FilepondModelTest extends TestCase
     /** @test */
     function can_update_filepond_model()
     {
-        $filepond = config('filepond.model')::create([
+        $filepond = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::create([
             'filepath' => Storage::disk(config('filepond.disk', 'public'))->path('fake_filename.png'),
             'filename' => 'fake_filename.png',
             'extension' => 'png',
@@ -53,7 +53,7 @@ class FilepondModelTest extends TestCase
     /** @test */
     function can_soft_delete_filepond_model()
     {
-        $filepond = config('filepond.model')::create([
+        $filepond = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::create([
             'filepath' => Storage::disk(config('filepond.disk', 'public'))->path('fake_filename.png'),
             'filename' => 'fake_filename.png',
             'extension' => 'png',
@@ -71,7 +71,7 @@ class FilepondModelTest extends TestCase
     /** @test */
     function can_force_delete_filepond_model()
     {
-        $filepond = config('filepond.model')::create([
+        $filepond = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::create([
             'filepath' => Storage::disk(config('filepond.disk', 'public'))->path('fake_filename.png'),
             'filename' => 'fake_filename.png',
             'extension' => 'png',

--- a/tests/Unit/FilepondProcessRouteTest.php
+++ b/tests/Unit/FilepondProcessRouteTest.php
@@ -50,7 +50,7 @@ class FilepondProcessRouteTest extends TestCase
 
         $data = Crypt::decrypt($response->content(), true);
 
-        $fileById = config('filepond.model')::find($data['id']);
+        $fileById = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::find($data['id']);
 
         Storage::disk(config('filepond.temp_disk', 'local'))->assertExists($fileById->filepath);
     }
@@ -73,7 +73,7 @@ class FilepondProcessRouteTest extends TestCase
             ]);
 
         $data = Crypt::decrypt($response->content(), true);
-        $filepondModel = config('filepond.model')::find($data['id']);
+        $filepondModel = config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::find($data['id']);
 
 		$this->assertEquals($user->id, $filepondModel->created_by);
 		$this->assertEquals(1, $user->fileponds->count());

--- a/tests/Unit/FilepondProcessRouteTest.php
+++ b/tests/Unit/FilepondProcessRouteTest.php
@@ -6,7 +6,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Storage;
-use RahulHaque\Filepond\Models\Filepond;
 use RahulHaque\Filepond\Tests\TestCase;
 use RahulHaque\Filepond\Tests\User;
 
@@ -51,8 +50,36 @@ class FilepondProcessRouteTest extends TestCase
 
         $data = Crypt::decrypt($response->content(), true);
 
-        $fileById = Filepond::find($data['id']);
+        $fileById = config('filepond.model')::find($data['id']);
 
         Storage::disk(config('filepond.temp_disk', 'local'))->assertExists($fileById->filepath);
     }
+
+
+    /** @test */
+    function can_assing_creator_to_model_and_has_correct_relationship_mapping()
+    {
+        Storage::disk(config('filepond.temp_disk', 'local'))->deleteDirectory(config('filepond.temp_folder', 'filepond/temp'));
+        $user = User::factory()->create();
+	    $fileName = 'avatar.png';
+
+	    $response = $this
+            ->actingAs($user)
+            ->post(route('filepond-process'), [
+                'avatar' => UploadedFile::fake()->image($fileName, 100, 100)
+            ], [
+                'Content-Type' => 'multipart/form-data',
+                'accept' => 'application/json'
+            ]);
+
+        $data = Crypt::decrypt($response->content(), true);
+        $filepondModel = config('filepond.model')::find($data['id']);
+
+		$this->assertEquals($user->id, $filepondModel->created_by);
+		$this->assertEquals(1, $user->fileponds->count());
+		$this->assertEquals($fileName, $user->fileponds->first()->filename);
+    }
+
+
+
 }


### PR DESCRIPTION
This PR will allow devs to use a custom FilePondModel.
The following entry was added in config file allowing to specify the new model:
```php
	/*
	|--------------------------------------------------------------------------
	| Filepond Model
	|--------------------------------------------------------------------------
	|
	| If you need to  customize the model, create a new one an extends the default model \RahulHaque\Filepond\Models\Filepond::class
	|
	*/
	'model' => \RahulHaque\Filepond\Models\Filepond::class,
```

It has no breakchange since even if this entry is not added into config file, all call to get the config model has the default value:
```php
config('filepond.model', \RahulHaque\Filepond\Models\Filepond::class)::truncate();
```