### PR TITLE
Fix Compatibility Issue with Non-Local Temp Disks

### DIFF
--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -2,7 +2,6 @@
 
 namespace RahulHaque\Filepond;
 
-use Illuminate\Http\File;
 use Illuminate\Support\Facades\Storage;
 use RahulHaque\Filepond\Models\Filepond as FilepondModel;
 
@@ -185,7 +184,11 @@ class Filepond extends AbstractFilepond
 
         $pathInfo = pathinfo($path);
 
-        Storage::disk($permanentDisk)->putFileAs($pathInfo['dirname'], new File(Storage::disk($this->getTempDisk())->path($filepond->filepath)), $pathInfo['filename'].'.'.$filepond->extension, $visibility);
+        Storage::disk($permanentDisk)->writeStream(
+            $pathInfo['dirname'].DIRECTORY_SEPARATOR.$pathInfo['filename'].'.'.$filepond->extension,
+            Storage::disk($this->getTempDisk())->readStream($filepond->filepath),
+            ['visibility' => $visibility],
+        );
 
         return [
             'id' => $filepond->id,


### PR DESCRIPTION
This pull request addresses a compatibility issue introduced by a recent fix for uploading large files. The previous implementation retrieved the path from the disk driver and attempted to instantiate a File object, which only references a path in the local filesystem and therefore caused problems with non-local temp disks (e.g., S3).

https://github.com/rahulhaque/laravel-filepond/blob/4a6f7a7b265b5631c567263d81644c416a5c1d04/src/Filepond.php#L188

Changes made:

- Updated the putFile method to use read and write streams.

https://github.com/viicslen/laravel-filepond/blob/76467992739ef90bdeabef797853d3e97e789bc4/src/Filepond.php#L187-L191

This change ensures compatibility with both large file uploads and external temp disks, avoiding the need to reference local filesystem paths.