### PR TITLE
Fix overriding the disk default visibility

### DIFF
--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -188,7 +188,7 @@ class Filepond extends AbstractFilepond
         Storage::disk($permanentDisk)->writeStream(
             $pathInfo['dirname'].DIRECTORY_SEPARATOR.$pathInfo['filename'].'.'.$filepond->extension,
             Storage::disk($this->getTempDisk())->readStream($filepond->filepath),
-            ['visibility' => $visibility],
+            $visibility !== '' ? ['visibility' => $visibility] : [],
         );
 
         return [


### PR DESCRIPTION
This pull request includes a small update to the `putFile` function in the `src/Filepond.php` file. The change ensures that the `visibility` option is only included if it is not an empty string, and therefore not overriding the default visibility set in the disk.