### PR TITLE
Filepond model null during upload in rare cases fixed 🐛

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `laravel-filepond` will be documented in this file.
 
+## 12.3.6 - 2026-03-05
+
+- Filepond model null during upload in rare cases fixed. 🐛
+- New test cases added to support above changes. 🧪
+
 ## 12.3.5 - 2026-01-30
 
 - Fail-safe expired files cleanup added. 🐛
@@ -13,7 +18,7 @@ All notable changes to `laravel-filepond` will be documented in this file.
 ## 12.3.3 - 2025-10-02
 
 - Unsupported disk driver exception for `getFile()` method added. ✅
-- New test cases updated to support above changes. 🧪
+- New test cases added to support above changes. 🧪
 
 ## 12.3.2 - 2025-10-01
 

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -32,7 +32,7 @@ class Filepond extends AbstractFilepond
      */
     public function getFile()
     {
-        if (! $this->getFieldValue()) {
+        if (! $this->getFieldValue() || ! $this->getFieldModel()) {
             return null;
         }
 

--- a/src/Models/Filepond.php
+++ b/src/Models/Filepond.php
@@ -20,7 +20,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $upload_id
  * @property array $upload_tags
  * @property int $created_by
- * @property \Illuminate\Support\Carbon $expired_at
+ * @property \Illuminate\Support\Carbon $expires_at
  * @property \Illuminate\Support\Carbon $deleted_at
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
@@ -33,6 +33,7 @@ class Filepond extends Model
 
     protected $casts = [
         'upload_tags' => 'json',
+        'expires_at' => 'datetime',
     ];
 
     protected $table = 'fileponds';

--- a/tests/Feature/FilepondValidationTest.php
+++ b/tests/Feature/FilepondValidationTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use PHPUnit\Framework\Attributes\Test;
+use RahulHaque\Filepond\Facades\Filepond;
 use RahulHaque\Filepond\Tests\TestCase;
 use RahulHaque\Filepond\Tests\User;
 
@@ -177,6 +178,42 @@ class FilepondValidationTest extends TestCase
                 'galleries.4.image' => [
                     'The galleries.4.image field must be a file of type: jpg.',
                     'The galleries.4.image field must be 30 kilobytes.',
+                ],
+            ]);
+        }
+    }
+
+    #[Test]
+    public function can_validate_missing_model_file_upload()
+    {
+        Storage::disk(config('filepond.temp_disk', 'local'))->deleteDirectory(config('filepond.temp_folder', 'filepond/temp'));
+
+        $user = User::factory()->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->post(route('filepond-process'), [
+                'avatar' => UploadedFile::fake()->image('avatar.png', 1024, 1024),
+            ], [
+                'Content-Type' => 'multipart/form-data',
+                'Accept' => 'application/json',
+            ]);
+
+        $request = new Request([
+            'avatar' => $response->content(),
+        ]);
+
+        // Simulating model deleted before get file is called
+        Filepond::field($response->content())->delete();
+
+        try {
+            $request->validate([
+                'avatar' => Rule::filepond('required|image|mimes:jpg|size:30'),
+            ]);
+        } catch (ValidationException $e) {
+            $this->assertEquals($e->errors(), [
+                'avatar' => [
+                    'The avatar field is required.',
                 ],
             ]);
         }

--- a/tests/Unit/FilepondModelTest.php
+++ b/tests/Unit/FilepondModelTest.php
@@ -21,7 +21,7 @@ class FilepondModelTest extends TestCase
             'mimetypes' => 'image/png',
             'disk' => 'filepond',
             'created_by' => 1,
-            'expires_at' => now()->addMinutes(30)->toISOString(),
+            'expires_at' => now()->addMinutes(30),
         ];
 
         Filepond::create($data);
@@ -39,7 +39,7 @@ class FilepondModelTest extends TestCase
             'mimetypes' => 'image/png',
             'disk' => 'filepond',
             'created_by' => 1,
-            'expires_at' => now()->addMinutes(30)->toISOString(),
+            'expires_at' => now()->addMinutes(30),
         ]);
 
         $filename = 'new_filename.png';
@@ -60,7 +60,7 @@ class FilepondModelTest extends TestCase
             'mimetypes' => 'image/png',
             'disk' => 'filepond',
             'created_by' => 1,
-            'expires_at' => now()->addMinutes(30)->toISOString(),
+            'expires_at' => now()->addMinutes(30),
         ]);
 
         $filepond->delete();
@@ -78,7 +78,7 @@ class FilepondModelTest extends TestCase
             'mimetypes' => 'image/png',
             'disk' => 'filepond',
             'created_by' => 1,
-            'expires_at' => now()->addMinutes(30)->toISOString(),
+            'expires_at' => now()->addMinutes(30),
         ]);
 
         $filepond->forceDelete();


### PR DESCRIPTION
This pull request aims to fix an age long issue where users randomly get this exception - `createFileObject(): Argument #1 ($filepond) must be of type RahulHaque\Filepond\Models\Filepond, null given`. It happens because the underlying filepond model gets deleted right after the file is done uploading by the filepond clear expired files scheduled command. As the `expires_at` column was missing proper casting to datetime type, different timezone would affect the expired file pruning process.