### PR TITLE
Feat/laravel 13 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,16 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [12.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-stable]
         include:
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to `laravel-filepond` will be documented in this file.
 
-## Unreleased
-
-- Laravel 13 support added. ✨
-
 ## 12.3.6 - 2026-03-05
 
 - Filepond model null during upload in rare cases fixed. 🐛

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-filepond` will be documented in this file.
 
+## Unreleased
+
+- Laravel 13 support added. ✨
+
 ## 12.3.6 - 2026-03-05
 
 - Filepond model null during upload in rare cases fixed. 🐛

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See the corresponding branch for the documentation.
 
 |Version|Branch|
 |:-:|:-:|
+|Laravel 13|[13.x branch](../../tree/13.x/README.md)|
 |Laravel 12|[12.x branch](../../tree/12.x/README.md)|
 |Laravel 11|[11.x branch](../../tree/11.x/README.md)|
 |Laravel 10|[10.x branch](../../tree/10.x/README.md)|
@@ -48,10 +49,10 @@ See the corresponding branch for the documentation.
 
 ## Installation
 
-Laravel 12 users install with.
+Laravel 12/13 users install with.
 
 ```bash
-composer require rahulhaque/laravel-filepond:"^12.0"
+composer require rahulhaque/laravel-filepond:"^12.0 || ^13.0"
 ```
 
 Publish the configuration and migration files.

--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ I’ve spent countless hours building and maintaining this package by developing
 
 See the corresponding branch for the documentation.
 
-|Version|Branch|
-|:-:|:-:|
-|Laravel 13|[13.x branch](../../tree/13.x/README.md)|
-|Laravel 12|[12.x branch](../../tree/12.x/README.md)|
-|Laravel 11|[11.x branch](../../tree/11.x/README.md)|
-|Laravel 10|[10.x branch](../../tree/10.x/README.md)|
-|Laravel 9|[9.x branch](../../tree/9.x/README.md)|
-|Laravel 8|[8.x branch](../../tree/8.x/README.md)|
-|Laravel 7|[7.x branch](../../tree/7.x/README.md)|
+|  Version   |                  Branch                  |
+| :--------: | :--------------------------------------: |
+| Laravel 13 | [13.x branch](../../tree/13.x/README.md) |
+| Laravel 12 | [12.x branch](../../tree/12.x/README.md) |
+| Laravel 11 | [11.x branch](../../tree/11.x/README.md) |
+| Laravel 10 | [10.x branch](../../tree/10.x/README.md) |
+| Laravel 9  |  [9.x branch](../../tree/9.x/README.md)  |
+| Laravel 8  |  [8.x branch](../../tree/8.x/README.md)  |
+| Laravel 7  |  [7.x branch](../../tree/7.x/README.md)  |
 
 ## Installation
 
@@ -80,32 +80,34 @@ Let's assume we are updating a user avatar and his/her gallery like the form bel
 
 ```html
 <form action="{{ route('avatar') }}" method="post">
-    @csrf
-    <!--  For single file upload  -->
-    <input type="file" name="avatar" required/>
-    <p class="help-block">{{ $errors->first('avatar') }}</p>
+  @csrf
+  <!--  For single file upload  -->
+  <input type="file" name="avatar" required />
+  <p class="help-block">{{ $errors->first('avatar') }}</p>
 
-    <!--  For multiple file uploads  -->
-    <input type="file" name="gallery[]" multiple required/>
-    <p class="help-block">{{ $errors->first('gallery.*') }}</p>
+  <!--  For multiple file uploads  -->
+  <input type="file" name="gallery[]" multiple required />
+  <p class="help-block">{{ $errors->first('gallery.*') }}</p>
 
-    <button type="submit">Submit</button>
+  <button type="submit">Submit</button>
 </form>
 
 <script>
-    // Set default FilePond options
-    FilePond.setOptions({
-        server: {
-            url: "{{ config('filepond.server.url') }}",
-            headers: {
-                'X-CSRF-TOKEN': "{{ csrf_token() }}",
-            }
-        }
-    });
+  // Set default FilePond options
+  FilePond.setOptions({
+    server: {
+      url: "{{ config('filepond.server.url') }}",
+      headers: {
+        "X-CSRF-TOKEN": "{{ csrf_token() }}",
+      },
+    },
+  });
 
-    // Create the FilePond instance
-    FilePond.create(document.querySelector('input[name="avatar"]'));
-    FilePond.create(document.querySelector('input[name="gallery[]"]'), {chunkUploads: true});
+  // Create the FilePond instance
+  FilePond.create(document.querySelector('input[name="avatar"]'));
+  FilePond.create(document.querySelector('input[name="gallery[]"]'), {
+    chunkUploads: true,
+  });
 </script>
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,80 +1,80 @@
 {
-    "name": "rahulhaque/laravel-filepond",
-    "description": "Use FilePond the Laravel way",
-    "keywords": [
-        "filepond-laravel",
-        "laravel-filepond",
-        "filepond"
-    ],
-    "homepage": "https://github.com/rahulhaque/laravel-filepond",
-    "license": "MIT",
-    "type": "library",
-    "authors": [
-        {
-            "name": "Rahul Haque",
-            "email": "rahulhaque07@gmail.com",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "laravel/framework": "^12.0 || ^13.0"
-    },
-    "require-dev": {
-        "fakerphp/faker": "^1.24.1",
-        "laravel/pail": "^1.2.3",
-        "laravel/pint": "^1.24",
-        "laravel/sail": "^1.45",
-        "league/flysystem-aws-s3-v3": "^3.29",
-        "mockery/mockery": "^1.6.12",
-        "nunomaduro/collision": "^8.8.2",
-        "orchestra/testbench": "^10.6 || ^11.0",
-        "phpunit/phpunit": "^11.5.38"
-    },
-    "autoload": {
-        "psr-4": {
-            "RahulHaque\\Filepond\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "RahulHaque\\Filepond\\Tests\\": "tests",
-            "Workbench\\App\\": "workbench/app/",
-            "Workbench\\Database\\Factories\\": "workbench/database/factories/",
-            "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"
-        }
-    },
-    "scripts": {
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
-        "post-autoload-dump": [
-            "@clear",
-            "@prepare"
-        ],
-        "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
-        "prepare": "@php vendor/bin/testbench package:discover --ansi",
-        "build": "@php vendor/bin/testbench workbench:build --ansi",
-        "serve": [
-            "Composer\\Config::disableProcessTimeout",
-            "@build",
-            "@php vendor/bin/testbench serve --ansi"
-        ],
-        "lint": [
-            "@php vendor/bin/pint",
-            "@php vendor/bin/phpstan analyse"
-        ]
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "RahulHaque\\Filepond\\FilepondServiceProvider"
-            ],
-            "aliases": {
-                "Filepond": "RahulHaque\\Filepond\\Facades\\Filepond"
-            }
-        }
+  "name": "rahulhaque/laravel-filepond",
+  "description": "Use FilePond the Laravel way",
+  "keywords": [
+    "filepond-laravel",
+    "laravel-filepond",
+    "filepond"
+  ],
+  "homepage": "https://github.com/rahulhaque/laravel-filepond",
+  "license": "MIT",
+  "type": "library",
+  "authors": [
+    {
+      "name": "Rahul Haque",
+      "email": "rahulhaque07@gmail.com",
+      "role": "Developer"
     }
+  ],
+  "require": {
+    "php": "^8.2",
+    "laravel/framework": "^12.0 || ^13.0"
+  },
+  "require-dev": {
+    "fakerphp/faker": "^1.24.1",
+    "laravel/pail": "^1.2.3",
+    "laravel/pint": "^1.24",
+    "laravel/sail": "^1.45",
+    "league/flysystem-aws-s3-v3": "^3.29",
+    "mockery/mockery": "^1.6.12",
+    "nunomaduro/collision": "^8.8.2",
+    "orchestra/testbench": "^10.6 || ^11.0",
+    "phpunit/phpunit": "^11.5.38"
+  },
+  "autoload": {
+    "psr-4": {
+      "RahulHaque\\Filepond\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "RahulHaque\\Filepond\\Tests\\": "tests",
+      "Workbench\\App\\": "workbench/app/",
+      "Workbench\\Database\\Factories\\": "workbench/database/factories/",
+      "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"
+    }
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit",
+    "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+    "post-autoload-dump": [
+      "@clear",
+      "@prepare"
+    ],
+    "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
+    "prepare": "@php vendor/bin/testbench package:discover --ansi",
+    "build": "@php vendor/bin/testbench workbench:build --ansi",
+    "serve": [
+      "Composer\\Config::disableProcessTimeout",
+      "@build",
+      "@php vendor/bin/testbench serve --ansi"
+    ],
+    "lint": [
+      "@php vendor/bin/pint",
+      "@php vendor/bin/phpstan analyse"
+    ]
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "RahulHaque\\Filepond\\FilepondServiceProvider"
+      ],
+      "aliases": {
+        "Filepond": "RahulHaque\\Filepond\\Facades\\Filepond"
+      }
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "laravel/framework": "^12.0"
+        "laravel/framework": "^12.0 || ^13.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.24.1",
@@ -28,7 +28,7 @@
         "league/flysystem-aws-s3-v3": "^3.29",
         "mockery/mockery": "^1.6.12",
         "nunomaduro/collision": "^8.8.2",
-        "orchestra/testbench": "^10.6",
+        "orchestra/testbench": "^10.6 || ^11.0",
         "phpunit/phpunit": "^11.5.38"
     },
     "autoload": {


### PR DESCRIPTION
# Add Laravel 13 compatibility (while keeping Laravel 12 support)

This PR adds Laravel 13 support without breaking Laravel 12 compatibility.

## Changes

- Update `composer.json` constraints:
  - `laravel/framework`: `^12.0 || ^13.0`
  - `orchestra/testbench`: `^10.6 || ^11.0`
- Update CI matrix in `.github/workflows/main.yml` to test Laravel 12 and 13.
- Update docs/changelog to mention Laravel 13 support.

## Validation

- `composer validate` passes.
- Tests pass locally (`vendor/bin/phpunit --exclude-group disk-test`).