### PR TITLE
Add migration to update changed columns

### DIFF
--- a/database/migrations/update_fileponds_table.php.stub
+++ b/database/migrations/update_fileponds_table.php.stub
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('fileponds', function (Blueprint $table) {
+            $table->renameColumn('mimetypes', 'mimetype');
+        });
+
+        Schema::table('fileponds', function (Blueprint $table) {
+            $table->json('metadata')->after('mimetype')->nullable();
+            $table->text('upload_id')->nullable()->after('metadata');
+            $table->json('upload_tags')->nullable()->after('upload_id');
+            $table->unsignedBigInteger('created_by')->nullable()->index()->change();
+            $table->index('expires_at');
+            $table->index('deleted_at');
+        });
+        
+    }
+
+    public function down(): void
+    {
+        Schema::table('fileponds', function (Blueprint $table) {
+            $table->renameColumn('mimetype', 'mimetypes');
+        });
+
+        Schema::table('fileponds', function (Blueprint $table) {
+            $table->dropColumn(['metadata', 'upload_id', 'upload_tags']);
+            $table->unsignedBigInteger('created_by')->nullable()->change(); // remove index
+            $table->dropIndex(['created_by']);
+            $table->dropIndex(['expires_at']);
+            $table->dropIndex(['deleted_at']);
+        });
+    }
+};


### PR DESCRIPTION
Hi @alloylab @rahulhaque,
I see that you are updating column properties directly in the existing migration, which is not a convenient, It would cause errors for users who are upgrading from older versions, It just happened to me, I updated from v8 to v11 and the changed migration didn't run cuz it already ran when I first installed the package, then an error of column 'mimetype' doesn't exist surfaced cuz it was renamed in earlier versions.

**The conventional good practice is to add new migration files for each new change or update added to the table.**

I have looked at the history of the original migration file and created a file for updating the table with those changes for users who already have migrated the original file before you guys added those changes.